### PR TITLE
overview-broker -> overview-service in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,12 @@ npm test
 
 * Now for the exciting part... it's time to create a new service instance:
     ```bash
-    cf create-service overview-broker simple my-broker
+    cf create-service overview-service simple my-instance
     ```
     You can give your service a specific name in the dashboard by providing the
     `name` configuration parameter:
     ```bash
-    cf create-service overview-broker simple my-broker -c '{ "name": "My Broker" }'
+    cf create-service overview-service simple my-instance -c '{ "name": "My Service Instance" }'
     ```
 * If you now head back to the dashboard, you should see your new service
 instance information.


### PR DESCRIPTION
Fixes the cf-specific docs for creating a service instance to match the rename of the service from `overview-broker` to `overview-service`.

I also just renamed the service instance itself from "my-broker" to "my-instance" to avoid confusion.

I didn't have a chance to investigate whether the Kubernetes instructions need a similar rename.