### PR TITLE
Reference the self scope instead of this

### DIFF
--- a/service_broker_interface.js
+++ b/service_broker_interface.js
@@ -521,7 +521,7 @@ class ServiceBrokerInterface {
             self.updateOperation(self.instanceOperations[key], key);
         });
         Object.keys(this.bindingOperations).forEach(function(key) {
-            self.updateOperation(this.bindingOperations[key], key);
+            self.updateOperation(self.bindingOperations[key], key);
         });
     }
 


### PR DESCRIPTION
Otherwise we get a `null` pointer and app crash when creating asynchronous service bindings.