### PR TITLE
Update to express-validator@6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -676,12 +676,12 @@
       }
     },
     "express-validator": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-5.3.1.tgz",
-      "integrity": "sha512-g8xkipBF6VxHbO1+ksC7nxUU7+pWif0+OZXjZTybKJ/V0aTVhuCoHbyhIPgSYVldwQLocGExPtB2pE0DqK4jsw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.1.1.tgz",
+      "integrity": "sha512-AF6YOhdDiCU7tUOO/OHp2W++I3qpYX7EInMmEEcRGOjs+qoubwgc5s6Wo3OQgxwsWRGCxXlrF73SIDEmY4y3wg==",
       "requires": {
-        "lodash": "^4.17.10",
-        "validator": "^10.4.0"
+        "lodash": "^4.17.11",
+        "validator": "^11.0.0"
       }
     },
     "extend": {
@@ -2304,9 +2304,9 @@
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "validator": {
-      "version": "10.11.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
-      "integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw=="
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-11.1.0.tgz",
+      "integrity": "sha512-qiQ5ktdO7CD6C/5/mYV4jku/7qnqzjrxb3C/Q5wR3vGGinHTgJZN/TdFT3ZX4vXhX2R1PXx42fB1cn5W+uJ4lg=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "cfenv": "^1.2.2",
     "express": "^4.17.1",
     "express-basic-auth": "^1.2.0",
-    "express-validator": "^5.3.1",
+    "express-validator": "^6.1.1",
     "jsonschema": "latest",
     "moment": "^2.24.0",
     "morgan": "^1.9.1",


### PR DESCRIPTION
express-validtor@6 drops the "Legacy API" meaning that we have to
refactor and use the new API in order to stay up to date.

https://github.com/express-validator/express-validator/releases/v6.0.0